### PR TITLE
Update percentage detection calculation and update statistical summary columns

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -659,7 +659,9 @@ class App {
                 {title: translations[SummaryAtts.PercentDetected], data: SummaryAtts.PercentDetected},
                 {title: translations[SummaryAtts.Detected], data: SummaryAtts.Detected},
                 {title: translations[SummaryAtts.Samples], data: SummaryAtts.Samples},
-                {title: translations[SummaryAtts.SamplesWithConcentration], data: SummaryAtts.SamplesWithConcentration},
+                {title: translations[SummaryAtts.ConcentrationMean], data: SummaryAtts.ConcentrationMean},
+                {title: translations[SummaryAtts.ConcentrationRange], data: SummaryAtts.ConcentrationRange},
+                {title: translations[SummaryAtts.SamplesWithConcentration], data: SummaryAtts.SamplesWithConcentration}
             ];
 
             this.updateTable("#visualTable", tableColInfo, tableData);

--- a/app/backend.js
+++ b/app/backend.js
@@ -1229,9 +1229,12 @@ export class Model {
             currentData[SummaryAtts.Detected] = currentData[SummaryAtts.Detected].size;
             currentData[SummaryAtts.NotDetected] = currentData[SummaryAtts.NotDetected].size;
             currentData[SummaryAtts.NotTested] = currentData[SummaryAtts.NotTested].size;
+            currentData[SummaryAtts.Tested] = currentData[SummaryAtts.Detected] + currentData[SummaryAtts.NotDetected];
             currentData[SummaryAtts.Samples] = currentData[SummaryAtts.Samples].size;
-            currentData[SummaryAtts.PercentDetected] = `${NumberTools.toPercent(currentData[SummaryAtts.Detected], currentData[SummaryAtts.Samples], 2)}%`;
+            currentData[SummaryAtts.PercentDetected] = `${NumberTools.toPercent(currentData[SummaryAtts.Detected], currentData[SummaryAtts.Tested], 2)}%`;
             currentData[SummaryAtts.SamplesWithConcentration] = "";
+            currentData[SummaryAtts.ConcentrationMean] = "";
+            currentData[SummaryAtts.ConcentrationRange] = "";
         });
 
         tableData = Object.values(tableData).map((microorganismRows) => Object.values(microorganismRows));
@@ -1277,8 +1280,9 @@ export class Model {
                 currentData[SummaryAtts.Detected] = currentData[SummaryAtts.Detected].size;
                 currentData[SummaryAtts.NotDetected] = currentData[SummaryAtts.NotDetected].size;
                 currentData[SummaryAtts.NotTested] = currentData[SummaryAtts.NotTested].size;
+                currentData[SummaryAtts.Tested] = currentData[SummaryAtts.Detected] + currentData[SummaryAtts.NotDetected];
                 currentData[SummaryAtts.Samples] = currentData[SummaryAtts.Samples].size;
-                currentData[SummaryAtts.PercentDetected] = NumberTools.toPercent(currentData[SummaryAtts.Detected], currentData[SummaryAtts.Samples]);
+                currentData[SummaryAtts.PercentDetected] = NumberTools.toPercent(currentData[SummaryAtts.Detected], currentData[SummaryAtts.Tested]);
             });
             graphData = Object.values(graphData);
 

--- a/app/constants.js
+++ b/app/constants.js
@@ -185,10 +185,13 @@ export const SummaryAtts = {
     Detected: SampleState.Detected,
     NotTested: SampleState.NotTested,
     NotDetected: SampleState.NotDetected,
+    Tested: "tested",
     PercentDetected: "percentDetected",
     State: "state",
     StateVal: "stateVal",
-    SamplesWithConcentration: "samplesWithConcentrations"
+    SamplesWithConcentration: "samplesWithConcentrations",
+    ConcentrationMean: "concentrationMean",
+    ConcentrationRange: "concentrationRange"
 }
 
 // DefaultDims: Default dimensions used for certain dimension attributes
@@ -470,11 +473,13 @@ overviewBarGraphXAxisEN[NumberView.Percentage] = "Percentage";
 // names for the columns on the table
 const tableColsEN = {};
 tableColsEN[SummaryAtts.FoodName] = "Food Name";
-tableColsEN[SummaryAtts.Microorganism] = "Microorganisms";
+tableColsEN[SummaryAtts.Microorganism] = "Pathogen Branch";
 tableColsEN[SummaryAtts.PercentDetected] = "% Detected";
 tableColsEN[SummaryAtts.Detected] = "# Detected";
 tableColsEN[SummaryAtts.Samples] = "# Samples";
-tableColsEN[SummaryAtts.SamplesWithConcentration] = "# Samples with Concentration Data"
+tableColsEN[SummaryAtts.SamplesWithConcentration] = "# Samples with Conc. Data"
+tableColsEN[SummaryAtts.ConcentrationMean] = "Conc. Mean (cfu/g)"
+tableColsEN[SummaryAtts.ConcentrationRange] = "Conc. Range (cfu/g)"
 
 const LangEN = {
     "websiteTitle": "Microbiology Tool",
@@ -641,6 +646,8 @@ tableColsFR[SummaryAtts.PercentDetected] = REMPLACER_MOI;
 tableColsFR[SummaryAtts.Detected] = REMPLACER_MOI;
 tableColsFR[SummaryAtts.Samples] = REMPLACER_MOI;
 tableColsFR[SummaryAtts.SamplesWithConcentration] = REMPLACER_MOI;
+tableColsFR[SummaryAtts.ConcentrationMean] = "Conc. Mean (cfu/g)"
+tableColsFR[SummaryAtts.ConcentrationRange] = "Conc. Range (cfu/g)"
 
 const LangFR = {
     "websiteTitle": REMPLACER_MOI,


### PR DESCRIPTION
- denominitor in percent detected should not include `# not tested`, new formula is:
```
# detected / (# detected + # not detected)
```

- Added empty concentration columns to the statistical summary table