### PR TITLE
Fix year slider not working after language change

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -579,8 +579,8 @@ class App {
 
     // updateGraphOptions(): Updates the options for the graph
     updateGraphOptions() {
-        const selections = this.model.getSelection();
-        const inputs = this.model.getInputs();
+        let selections = this.model.getSelection();
+        let inputs = this.model.getInputs();
 
         // number/percentage view
         if (inputs[Inputs.NumberView] !== undefined) {
@@ -605,6 +605,9 @@ class App {
             
             this.updateRangeSlider({selectId: Inputs.Year, selection: selectionRange, input: inputRange,
                                     onChange: (sliderValue) => {
+                                        inputs = this.model.getInputs();
+                                        selections = this.model.getSelection();
+
                                         const selectionYear = DateTimeTools.rangeToDate(selections[Inputs.Year], ModelTimeZone, true);
                                         const inputYear = inputs[Inputs.Year];
 

--- a/app/constants.js
+++ b/app/constants.js
@@ -664,10 +664,10 @@ const denomGenusesFR = [[allMicroorganismsFR, "Bacteria", "Vibrio"].join(Phyloge
 // Different options for the qualitative results
 // Note: Copy the exact value from the "Qualitative Result" column in "CANLINE Micro -no... .csv", then convert the name to lowercase without any trailing/leading spaces
 const QualitaiveResultsFR = {};
-QualitaiveResultsFR[SampleState.Detected] = REMPLACER_MOI;
-QualitaiveResultsFR[SampleState.NotDetected] = REMPLACER_MOI;
-QualitaiveResultsFR[SampleState.NotTested] = REMPLACER_MOI;
-QualitaiveResultsFR[SampleState.InConclusive] = REMPLACER_MOI;
+QualitaiveResultsFR[SampleState.Detected] = "detected";
+QualitaiveResultsFR[SampleState.NotDetected] = "not detected";
+QualitaiveResultsFR[SampleState.NotTested] = "not tested";
+QualitaiveResultsFR[SampleState.InConclusive] = "inconclusive";
 
 // labels for the x-axis of the overview bar graph
 const overviewBarGraphXAxisFR = {};


### PR DESCRIPTION
The year slider was referencing outdated inputs/selections from the previous language. Want the year slider to reference the current inputs/selections of the language