### PR TITLE
Configured download data button

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -654,6 +654,10 @@ const LangEN = {
     denomGenuses: denomGenusesEN,
 
     "tableTitle": "Statistical Summary",
+    "csvTitle": {
+        "table": "{{ graphTitle }} {{ tableTitle }}",
+        "data": "{{ graphTitle }} Data"
+    },
     tableCols: tableColsEN,
     csvTableCols: csvtableColsEN,
     overviewBarGraph: overviewBarGraphEN,
@@ -661,6 +665,7 @@ const LangEN = {
 
     "downloadGraph": "Download Graph",
     "downloadTable": "Download Table",
+    "downloadData": "Download Data",
 
     // reference: https://datatables.net/plug-ins/i18n/English.html
     // note:
@@ -1124,6 +1129,10 @@ const LangFR = {
     numberview: NumberViewFR,
 
     "tableTitle": REMPLACER_MOI,
+    "csvTitle": {
+        "table": `${REMPLACER_MOI_AVEC_ARGUMENTS}{{ graphTitle }} {{ tableTitle }}`,
+        "data": `${REMPLACER_MOI_AVEC_ARGUMENTS}{{ graphTitle }}`
+    },
     tableCols: tableColsFR,
     csvTableCols: csvtableColsFR,
     overviewBarGraph: overviewBarGraphFR,
@@ -1131,6 +1140,7 @@ const LangFR = {
 
     "downloadGraph": REMPLACER_MOI,
     "downloadTable": REMPLACER_MOI,
+    "downloadData": REMPLACER_MOI,
 
     // references: https://datatables.net/plug-ins/i18n/French.html
     // note:


### PR DESCRIPTION
- For now, the CSV download contains all columns from Health Canada data. When CFIA data comes in, may need to decided on what columns to put into this download since CFIA data may have columns that are not in Health Canada data and vice versa.

- Using the old CSV download function fails to download the raw data since the data is too big that it takes up all the memory of the browser. Instead, we should stream the download to users by calling `URL.createObjectURL` that creates a new download object to be streamed.
https://stackoverflow.com/questions/30167326/unable-to-download-large-data-using-javascript

<br>

> [!WARNING]
> After we are done with the object from `URL.createObjectURL`, remember to FREE UP the object by calling `URL.revokeObjectURL` 
> https://developer.mozilla.org/en-US/docs/Web/API/URL/revokeObjectURL_static