### PR TITLE
Update denominator calculations

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -946,7 +946,8 @@ class App {
                 {title: "# of Samples", data: SummaryAtts.Samples},
                 {title: "# of Detected", data: SummaryAtts.Detected},
                 {title: "# of Not Detected", data: SummaryAtts.NotDetected},
-                {title: "# of Not Tested", data: SummaryAtts.NotTested}
+                {title: "# of Not Tested", data: SummaryAtts.NotTested},
+                {title: "# of Tested", data: SummaryAtts.Tested}
             ];
 
             this.updateTable("#tempGraphTable", tableColInfo, graphData);
@@ -960,7 +961,8 @@ class App {
                 {title: "# of Samples", data: SummaryAtts.Samples},
                 {title: "# of Detected", data: SummaryAtts.Detected},
                 {title: "# of Not Detected", data: SummaryAtts.NotDetected},
-                {title: "# of Not Tested", data: SummaryAtts.NotTested}
+                {title: "# of Not Tested", data: SummaryAtts.NotTested},
+                {title: "# of Tested", data: SummaryAtts.Tested}
             ];
 
             this.updateTable("#tempGraphTable", tableColInfo, graphData);


### PR DESCRIPTION
- Fix up the denominator to be `# of tested` instead of `# of samples`
- Update the denominator calculations for EColi for CFIA
- Have non-speciated microorganisms in the graph and table to always display their **_"Non-Speciated"_** suffix to distinguish between a genus row and a microorganism row in the summary table. In the [testing doc](https://docs.google.com/document/d/1PUY6j9wnTP38r62ANexpGhyd14cY5AjZMUEkTRffiyI/edit?usp=sharing), **Bacteria Listeria Monocytogenes** is supposed to have 0 _not-tested_ since that is referring to its **_"Non-Speciated"_**, not **Bacteria Listeria Monocytogenes** as a whole