### PR TITLE
Add tooltips to the Trends Over Time graph

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -468,6 +468,7 @@ export const Dims = {
         TooltipBorderWidth: 3,
         TooltipFontSize: 14,
         TooltipTitleMarginBtm: 10,
+        pointRadius: 3
     }
 }
 
@@ -964,33 +965,30 @@ overviewBarGraphEN[SummaryAtts.Microorganism] = {
 };
 
 // title/labels in the TrendsOverTime graph
-const trendsOverTimeGraphEN = {};
-trendsOverTimeGraphEN[SummaryAtts.FoodName] = {
-    "graphTitle": "Microorganisms Detected in Food",
-    "xAxis": trendsOverTimeXAxisEN,
-    "yAxis": trendsOverTimeYAxisEN,
-    "yAxisRight": "# Samples",
-
+const trendsOverTimeGraphEN = {
     "barTooltip": [
         "{{ subKey }}",
         "{{ detectedNum }} detected samples",
         "{{ testedNum }} tested samples",
         "{{ dateTime }}"
     ],
+    "pointTooltip": [
+        "{{ subKey }}",
+        "{{ dateTime }}"
+    ]
+};
+trendsOverTimeGraphEN[SummaryAtts.FoodName] = {
+    "graphTitle": "Microorganisms Detected in Food",
+    "xAxis": trendsOverTimeXAxisEN,
+    "yAxis": trendsOverTimeYAxisEN,
+    "yAxisRight": "# Samples"
 }
 
 trendsOverTimeGraphEN[SummaryAtts.Microorganism] = {
     "graphTitle": "Food Detected in Microorganisms",
     "xAxis": trendsOverTimeXAxisEN,
     "yAxis": trendsOverTimeYAxisEN,
-    "yAxisRight": "# Samples",
-    
-    "barTooltip": [
-        "{{ subKey }}",
-        "{{ detectedNum }} detected samples",
-        "{{ testedNum }} tested samples",
-        "{{ dateTime }}"
-    ],
+    "yAxisRight": "# Samples"
 }
 
 const LangEN = {
@@ -1498,42 +1496,30 @@ overviewBarGraphFR[SummaryAtts.FoodName] = {
 overviewBarGraphFR[SummaryAtts.Microorganism] = {
     "graphTitle": REMPLACER_MOI,
     "xAxis": overviewBarGraphXAxisFR,
-    "yAxis": REMPLACER_MOI,
-    "yAxisRight": REMPLACER_MOI 
+    "yAxis": REMPLACER_MOI
 };
 
 // title/labels in the TrendsOverTime graph
 const trendsOverTimeGraphFR = {
     "barTooltip": [
-        "Datetime: {{ dateTime }}",
-        "Detected: {{ number }}"
+        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ subKey }}`,
+        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ detectedNum }}`,
+        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ testedNum }}`,
+        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ dateTime }}`
     ],
 };
 trendsOverTimeGraphFR[SummaryAtts.FoodName] = {
     "graphTitle": REMPLACER_MOI,
     "xAxis": trendsOverTimeXAxisFR,
     "yAxis": trendsOverTimeYAxisFR,
-    "yAxisRight": REMPLACER_MOI,
-
-    "barTooltip": [
-        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ subKey }}`,
-        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ detectedNum }}`,
-        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ testedNum }}`,
-        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ dateTime }}`
-    ],
+    "yAxisRight": REMPLACER_MOI
 }
 
 trendsOverTimeGraphFR[SummaryAtts.Microorganism] = {
     "graphTitle": REMPLACER_MOI,
     "xAxis": trendsOverTimeXAxisFR,
     "yAxis": trendsOverTimeYAxisFR,
-
-    "barTooltip": [
-        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ subKey }}`,
-        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ detectedNum }}`,
-        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ testedNum }}`,
-        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ dateTime }}`
-    ],
+    "yAxisRight": REMPLACER_MOI
 }
 
 const LangFR = {

--- a/app/constants.js
+++ b/app/constants.js
@@ -972,9 +972,10 @@ trendsOverTimeGraphEN[SummaryAtts.FoodName] = {
     "yAxisRight": "# Samples",
 
     "barTooltip": [
-        "Microorganism: {{ subKey }}",
-        "Datetime: {{ dateTime }}",
-        "Detected: {{ number }}"
+        "{{ subKey }}",
+        "{{ detectedNum }} detected samples",
+        "{{ testedNum }} tested samples",
+        "{{ dateTime }}"
     ],
 }
 
@@ -985,9 +986,10 @@ trendsOverTimeGraphEN[SummaryAtts.Microorganism] = {
     "yAxisRight": "# Samples",
     
     "barTooltip": [
-        "Food: {{ subKey }}",
-        "Datetime: {{ dateTime }}",
-        "Detected: {{ number }}"
+        "{{ subKey }}",
+        "{{ detectedNum }} detected samples",
+        "{{ testedNum }} tested samples",
+        "{{ dateTime }}"
     ],
 }
 
@@ -1515,8 +1517,9 @@ trendsOverTimeGraphFR[SummaryAtts.FoodName] = {
 
     "barTooltip": [
         `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ subKey }}`,
-        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ dateTime }}`,
-        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ number }}`
+        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ detectedNum }}`,
+        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ testedNum }}`,
+        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ dateTime }}`
     ],
 }
 
@@ -1527,8 +1530,9 @@ trendsOverTimeGraphFR[SummaryAtts.Microorganism] = {
 
     "barTooltip": [
         `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ subKey }}`,
-        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ dateTime }}`,
-        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ number }}`
+        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ detectedNum }}`,
+        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ testedNum }}`,
+        `${REMPLACER_MOI_AVEC_ARGUMENTS} {{ dateTime }}`
     ],
 }
 


### PR DESCRIPTION
> [!NOTE]
> Did not add survey type to the tooltip since we do not have the field readily available for each micro-food combination. Also, do we want survey types of all samples or all detected?

<br>

- Optimized zooming by creating one global zoom transformation for all subgraphs instead of individual zoom transformations for each subgraph