### PR TITLE
Select "Dairy Products" in the food groups default

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -637,8 +637,13 @@ class App {
             selectAllText: Translation.translate("selectAll"),
             noneSelectedText,
             noneResultsText: Translation.translate("noResultsFound")});
+        
+        if (orderedSelections.length == inputs.size) {
+            dropdown.selectpicker('selectAll');
+        } else {
+            dropdown.selectpicker('val', Array.from(inputs));
+        }
 
-        dropdown.selectpicker('val', Array.from(inputs));
         dropdown.on('changed.bs.select', function (e, clickedIndex, isSelected, previousValue) {
             if (onChange !== undefined) {
                 onChange(dropdown.val());


### PR DESCRIPTION
- Seems like it is a bug with the [bootstrap-select](https://developer.snapappointments.com/bootstrap-select/) library. When all options are selected in the multi-select widget, trigger the [selectAll](https://developer.snapappointments.com/bootstrap-select/methods/#selectpickerselectall) method for the multi-select instead of manualy setting the values